### PR TITLE
fix: TS1484 when using verbatimModuleSyntax

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,7 @@
 import Elysia from "elysia";
 import postcss from "postcss";
-import tw, { Config } from "tailwindcss";
+import tw from "tailwindcss";
+import type { Config } from "tailwindcss";
 
 type Options = {
 	minify?: boolean;


### PR DESCRIPTION
This fix resolves an error thrown by tsc related to type-only imports when using TypeScript with the verbatimModuleSyntax option enabled.
```
$ tsc --skipLibCheck --noEmit --project tsconfig.json
node_modules/@gtramontina.com/elysia-tailwind/index.ts:3:14 - error TS1484: 'Config' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.
3 import tw, { Config } from "tailwindcss";
               ~~~~~~
Found 1 error in node_modules/@gtramontina.com/elysia-tailwind/index.ts:3
```

As a side note, you may want to build the project instead of publishing .ts files directly to avoid raising typecheck errors in the repos that consume your plugin with different contexts and setups.